### PR TITLE
added laravel-docsify to show full docs on https://laravelviews.com/docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "laravel/tinker": "^2.5",
         "owenvoke/blade-fontawesome": "^1.8",
         "spatie/laravel-ray": "^1.3",
-        "spatie/ray": "^1.3"
+        "spatie/ray": "^1.3",
+        "mdebuf/laravel-docsify": "dev-master"
     },
     "require-dev": {
         "facade/ignition": "^2.5",

--- a/config/docsify.php
+++ b/config/docsify.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Laravel Docsify
+    |--------------------------------------------------------------------------
+    |
+    | Find your docs at the given route.
+    |
+    */
+
+    'route' => 'docs',
+    'path' => 'vendor/laravel-views/laravel-views/doc/',
+
+];


### PR DESCRIPTION
Thank's for your package. it help me alot. you're awesome.

Actually your sample site and documentation are awesome to. But maybe many people like me. Not comfortable reading on github.

I think it will be more awesome if we can make it like docsify.

I have made it. But it's up to you. You don't have to merge it. I already use it on my local.

I made pull request on laravel docsify and laravel views packages for this to work.

https://github.com/mdebuf/laravel-docsify/pull/1
https://github.com/Gustavinho/laravel-views/pull/140

![image](https://user-images.githubusercontent.com/4870292/139719811-50faf082-bcf5-42b2-87e3-dd055974c252.png)
